### PR TITLE
Ansible 2 warnings and debian

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,6 @@ galaxy_info:
     versions:
     - trusty
     - precise
-    - xenial
   - name: Debian
     versions:
     - wheezy

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,11 @@ galaxy_info:
     versions:
     - trusty
     - precise
+    - xenial
+  - name: Debian
+    versions:
+    - wheezy
+    - jessie
   categories:
   - development
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,17 +9,17 @@
   get_url: url={{ item.url }} dest={{ instantclient_oracle_package_dest }}/{{ item.filename }}
            sha256sum={{ item.sha256 }}
   when: item.url is defined
-  with_items: "{{instantclient_oracle_packages}}"
+  with_items: "{{ instantclient_oracle_packages }}"
 
 - name: Copy oracle packages
   copy: src={{ instantclient_oracle_package_src }}/{{ item.filename }}
         dest={{ instantclient_oracle_package_dest }}/{{ item.filename }}
   when: item.url is not defined
-  with_items: "{{instantclient_oracle_packages}}"
+  with_items: "{{ instantclient_oracle_packages }}"
 
 - name: Install oracle packages
   apt: deb={{ instantclient_oracle_package_dest }}/{{ item.filename }}
-  with_items: "{{instantclient_oracle_packages}}"
+  with_items: "{{ instantclient_oracle_packages }}"
 
 - name: Create /etc/ld.so.conf.d/oracle.conf
   copy: content={{ instantclient_oracle_lib }} dest=/etc/ld.so.conf.d/oracle.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,17 +9,17 @@
   get_url: url={{ item.url }} dest={{ instantclient_oracle_package_dest }}/{{ item.filename }}
            sha256sum={{ item.sha256 }}
   when: item.url is defined
-  with_items: instantclient_oracle_packages
+  with_items: "{{instantclient_oracle_packages}}"
 
 - name: Copy oracle packages
   copy: src={{ instantclient_oracle_package_src }}/{{ item.filename }}
         dest={{ instantclient_oracle_package_dest }}/{{ item.filename }}
   when: item.url is not defined
-  with_items: instantclient_oracle_packages
+  with_items: "{{instantclient_oracle_packages}}"
 
 - name: Install oracle packages
   apt: deb={{ instantclient_oracle_package_dest }}/{{ item.filename }}
-  with_items: instantclient_oracle_packages
+  with_items: "{{instantclient_oracle_packages}}"
 
 - name: Create /etc/ld.so.conf.d/oracle.conf
   copy: content={{ instantclient_oracle_lib }} dest=/etc/ld.so.conf.d/oracle.conf


### PR DESCRIPTION
Ansible 2 produce this warning when playing the role:

```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{instantclient_oracle_packages}}').
This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

This patch fix this.

Also this role works an Debian Wheezy and Jessie. I also added Ubuntu Xenial for completeness but this one not tested.
